### PR TITLE
Set z-index and downgrade Radium dependency

### DIFF
--- a/package/@resource.json
+++ b/package/@resource.json
@@ -10,7 +10,7 @@
     "@ministate/base": "^0.1.8",
     "@ministate/react": "^0.1.4",
     "prop-types": "^15.6.2",
-    "radium": "^0.25.0",
+    "radium": "^0.24.0",
     "radium-starter": "^0.11.8",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",

--- a/package/src/components/container.js
+++ b/package/src/components/container.js
@@ -54,7 +54,8 @@ function generateStyle(t, s, props = {}) {
   const {width, maxHeight, position} = props;
   const style = {
     overlay: {
-      backgroundColor: 'rgba(0, 0, 0, 0.66)'
+      backgroundColor: 'rgba(0, 0, 0, 0.66)',
+      zIndex: 10000
     },
     content: {
       width: width || 500,


### PR DESCRIPTION
Goals:

* Set `z-index` to cover Annotation overlays in Image Editor page, when the modal is open.
* Downgrade Radium dependency, to be consistent with other Medmain packages and avoid duplicate in bundles.