### PR TITLE
Disable CSS transitions effects

### DIFF
--- a/package/src/components/container.js
+++ b/package/src/components/container.js
@@ -5,22 +5,26 @@ import ReactModal from 'react-modal';
 
 import {Style} from 'radium';
 
+const enableTransitionEffects = false; // disable CSS transitions until the state management issue is solved
+
 export const Container = ({onClose, children, ...props}) => {
   return (
     <RadiumStarter>
       {(t, s) => (
         <>
           {/* Add transition effect, see https://github.com/reactjs/react-modal/blob/921358e62e35c83775104d99edb258dad9cbbd05/docs/styles/transitions.md */}
-          <Style
-            rules={{
-              '.ReactModal__Content': {opacity: 0},
-              '.ReactModal__Content--after-open': {
-                opacity: 1,
-                transition: 'opacity 0.5s ease-in'
-              },
-              '.ReactModal__Content--before-close': {opacity: 0}
-            }}
-          />
+          {enableTransitionEffects && (
+            <Style
+              rules={{
+                '.ReactModal__Content': {opacity: 0},
+                '.ReactModal__Content--after-open': {
+                  opacity: 1,
+                  transition: 'opacity 0.5s ease-in'
+                },
+                '.ReactModal__Content--before-close': {opacity: 0}
+              }}
+            />
+          )}
           <ReactModal
             isOpen
             style={generateStyle(t, s, props)}


### PR DESCRIPTION
Goal: disable CSS transition effects when the modal is displayed, to prevent the modal from blinking when the application state changes.

This is a temporary fix, until the state management issue is fixed.