### PR TITLE
Create the React element only once

### DIFF
--- a/package/src/modal.js
+++ b/package/src/modal.js
@@ -17,8 +17,12 @@ export class Modal extends Base {
     };
   }
 
+  /* Create the React element only once, to avoid blinking effects when the application updates */
   createElement() {
-    return React.createElement(subscribe(this)(Stack), {modal: this});
+    if (!this._element) {
+      this._element = React.createElement(subscribe(this)(Stack), {modal: this});
+    }
+    return this._element;
   }
 
   dialog(options = {}) {


### PR DESCRIPTION
Goal: create the React element only once, to avoid blinking effects when the application updates (when `app.setState()` is called).

This means we can restore CSS transitions effect when the modal is displayed (see #3 )